### PR TITLE
Refactored pool.Run() into arbitrary function; updated pool_test.go w…

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ func run(p *Pool) {
         log.Fatal(fmt.Sprintf("worker count %s is not an integer", workerstr))
     }
 
+    // This loop is functionally the same as the default wp.DefaultRunner() but 
+    // defined here as an example of how to do custom implementations.
 	for i := 0; i < workercount; i++ {
 		p.wg.Add(1)
 		num := i

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ func main() {
         SinkWorkerCount: 4,
     }
 
-    musher := mush.Compose(ctx, reader, handle, writer, config)
+    musher := mush.Compose(ctx, reader, run, handle, writer, config)
     musher.Mush()
 
     musher.Wait()

--- a/mush.go
+++ b/mush.go
@@ -16,9 +16,9 @@ type BatchProvider = stream.BatchProvider
 type Writer = sink.Writer
 
 // Compose bootstraps a Musher from required service implementations and a configuration.
-func Compose(ctx context.Context, bp stream.BatchProvider, handler wp.Handler, writer sink.Writer, config Config) Musher {
+func Compose(ctx context.Context, bp stream.BatchProvider, runner wp.Runner, handler wp.Handler, writer sink.Writer, config Config) Musher {
 	streamer, _ := stream.New(ctx, bp, config.StreamBatchSize, config.StreamWaterline)
-	pool, _ := wp.New(ctx, config.PoolWorkerCount, handler)
+	pool, _ := wp.New(ctx, runner, handler)
 	sinker := sink.New(ctx, config.SinkWorkerCount, writer)
 
 	return &musher{
@@ -39,8 +39,6 @@ type Musher interface {
 type Config struct {
 	StreamBatchSize int
 	StreamWaterline int
-
-	PoolWorkerCount int
 
 	SinkWorkerCount int
 }

--- a/wp/pool_test.go
+++ b/wp/pool_test.go
@@ -19,32 +19,9 @@ func handler(n *note.Note) *note.Result {
 	}
 }
 
-func concurrentRunner(p *Pool) {
-	for i := 0; i < 3; i++ {
-		p.wg.Add(1)
-		go func() {
-			for {
-				select {
-				case n, ok := <-p.incoming:
-					if !ok {
-						p.wg.Done()
-						return
-					}
-					p.results <- p.handler(n)
-				case <-p.ctx.Done():
-					p.wg.Done()
-					return
-				}
-			}
-		}()
-	}
-	p.wg.Wait()
-	close(p.results)
-}
-
 func Test_Pool_With_Accept(t *testing.T) {
 	ctx, cf := context.WithCancel(context.Background())
-	pool, results := NewRunning(ctx, concurrentRunner, handler)
+	pool, results := NewRunning(ctx, DefaultRunner(3), handler)
 
 	rc := make(chan []*note.Result)
 	go func() {
@@ -72,7 +49,7 @@ func Test_Pool_With_Accept(t *testing.T) {
 
 func Test_Pool_With_Listen(t *testing.T) {
 	ctx, cf := context.WithCancel(context.Background())
-	pool, results := NewRunning(ctx, concurrentRunner, handler)
+	pool, results := NewRunning(ctx, DefaultRunner(3), handler)
 
 	notes := make(chan *note.Note, 10)
 	for i := 0; i < 10; i++ {

--- a/wp/pool_test.go
+++ b/wp/pool_test.go
@@ -12,14 +12,14 @@ type ConcurrentConfig struct {
 	concurrency int
 }
 
-func testHandler(n *note.Note) *note.Result {
+func handler(n *note.Note) *note.Result {
 	time.Sleep(10 * time.Millisecond)
 	return &note.Result{
 		ID: n.ID,
 	}
 }
 
-func testConcurrentRunner(p *Pool) {
+func concurrentRunner(p *Pool) {
 	for i := 0; i < 3; i++ {
 		p.wg.Add(1)
 		go func() {
@@ -44,7 +44,7 @@ func testConcurrentRunner(p *Pool) {
 
 func Test_Pool_With_Accept(t *testing.T) {
 	ctx, cf := context.WithCancel(context.Background())
-	pool, results := NewRunning(ctx, testConcurrentRunner, testHandler)
+	pool, results := NewRunning(ctx, concurrentRunner, handler)
 
 	rc := make(chan []*note.Result)
 	go func() {
@@ -72,7 +72,7 @@ func Test_Pool_With_Accept(t *testing.T) {
 
 func Test_Pool_With_Listen(t *testing.T) {
 	ctx, cf := context.WithCancel(context.Background())
-	pool, results := NewRunning(ctx, testConcurrentRunner, testHandler)
+	pool, results := NewRunning(ctx, concurrentRunner, handler)
 
 	notes := make(chan *note.Note, 10)
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
After some thought and experimentation, it seems that most functions in `Pool`are actually quite applicable to the use cases we've considered in the past. Ultimately then as far as I can tell, the best option would be to leave the `pool.Run()` function up to the implementer, similar to `Handler`. In this branch I've left both `Run()` and `Handle()` as separate implementation-specific functions, but if we go this route we could even drop `Handle()` and just leave `Run()` up to the implementer, as `Handle()` is only called within `Run()` anyway.

@cspital , thoughts? 

I updated `mush/wp/pool_test.go` with an implementation of the previous concurrent `Run()` to demonstrate how it can be used (as well as the README).

Let me know what you think when you have a chance to take a look.